### PR TITLE
Feat/#271: 웨일비 캐러셀 클릭 시 상세 페이지로 이동하도록 추가

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -11,6 +11,7 @@ interface WhalebeData {
   title: string;
   date: string;
   imgUrl: string;
+  link: string;
 }
 
 const Carousel = () => {
@@ -43,16 +44,16 @@ const Carousel = () => {
           carouselData.map((data) => (
             <div
               key={data.title}
-              onClick={() =>
-                window.open('https://whalebe.pknu.ac.kr/main', '_blank')
-              }
+              onClick={() => window.open(data.link, '_blank')}
             >
               <SliderWrapper>
                 <img src={data.imgUrl} width="100%" height={200} />
               </SliderWrapper>
               <Title>{data.title}</Title>
               <Date>모집기간: ~ {data.date}</Date>
-              <Button>자세히보기</Button>
+              <DisplayCenterWrapper>
+                <Button>자세히보기</Button>
+              </DisplayCenterWrapper>
             </div>
           ))}
       </Slider>
@@ -94,7 +95,7 @@ const Button = styled.button`
   border: 1px solid ${THEME.PRIMARY};
   color: ${THEME.PRIMARY};
   background: none;
-  width: 100%;
+  width: 95%;
   height: 3rem;
   border-radius: 0.5rem;
   margin-top: 1rem;
@@ -102,4 +103,8 @@ const Button = styled.button`
   &: hover {
     cursor: pointer;
   }
+`;
+
+const DisplayCenterWrapper = styled.div`
+  text-align: center;
 `;

--- a/src/mocks/handlers/announceHandlers.ts
+++ b/src/mocks/handlers/announceHandlers.ts
@@ -96,18 +96,21 @@ export const announceHandlers: RequestHandler[] = [
         date: '2023.09.17',
         imgUrl:
           'https://whalebe.pknu.ac.kr/upload/program/2023/09/13/66e59b5f-4cb9-41fc-b65a-79c2d843229a.png',
+        link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003002&nonsubjcCd=N202309038&nonsubjcCrsCd=C201900053',
       },
       {
         title: '전공별 CDP(생물/생명과학, 바이오/제약)',
         date: '2023.09.17',
         imgUrl:
           'https://whalebe.pknu.ac.kr/upload/program/2023/09/13/c207c16f-a57d-4216-8e6a-4ee53fead465.png',
+        link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003002&nonsubjcCd=N202310003&nonsubjcCrsCd=C202301005',
       },
       {
         title: '전공별 CDP(인문/상경계열, 마케팅, 인사, 영업, 경영기획 등)',
         date: '2023.09.17',
         imgUrl:
           'https://whalebe.pknu.ac.kr/upload/program/2023/09/13/4e4b7e74-28d4-4758-b80d-babe6ec1d286.png',
+        link: 'https://whalebe.pknu.ac.kr/main/65?action=get&yy=2023&shtm=U0003002&nonsubjcCd=N202309059&nonsubjcCrsCd=C202306003',
       },
     ];
     return res(ctx.status(200), ctx.json(mockData));


### PR DESCRIPTION
## 🤠 개요

- closes: #271 
- @hwinkr 덕분에 웨일이 페이지 조회가 로그인없이 가능하도록 되었기에 로그인 없이 웨일비 상세 페이지를 볼 수 있게 되었어요
- 현재는 캐러셀 클릭 시 웨일비 홈으로 가도록 되어있는데 상세 페이지로 이동하도록 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/71641127/9c56f5c7-d7b9-4620-99ee-3c22b26fd8fb


