### PR TITLE
Style/#273: 공지사항 리스트 UI 변경

### DIFF
--- a/src/@types/announcement.ts
+++ b/src/@types/announcement.ts
@@ -1,3 +1,8 @@
+import {
+  ANNOUNCEMENT_CATEGORY,
+  ANNOUNCEMENT_TYPE,
+} from '@constants/announcement';
+
 type AnnounceItemType = '고정' | '일반';
 
 export interface AnnounceItem {
@@ -11,3 +16,9 @@ export interface AnnounceItem {
 export type AnnounceItemList = {
   [key in AnnounceItemType]: AnnounceItem[];
 };
+
+export type AnnouncementCategory =
+  (typeof ANNOUNCEMENT_CATEGORY)[keyof typeof ANNOUNCEMENT_CATEGORY];
+
+export type AnnouncementType =
+  (typeof ANNOUNCEMENT_TYPE)[keyof typeof ANNOUNCEMENT_TYPE];

--- a/src/components/Card/AnnounceCard/AnnounceList/index.tsx
+++ b/src/components/Card/AnnounceCard/AnnounceList/index.tsx
@@ -1,5 +1,10 @@
-import { AnnounceItemList } from '@type/announcement';
+import { ANNOUNCEMENT_TYPE } from '@constants/announcement';
+import styled from '@emotion/styled';
+import { AnnounceSearchList } from '@pages/Announcement/components';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { AnnounceItemList, AnnouncementType } from '@type/announcement';
 import { AxiosError, AxiosResponse } from 'axios';
+import { Fragment } from 'react';
 
 import AnnounceCard from '..';
 
@@ -13,30 +18,44 @@ interface AnnounceListProps {
   resource: {
     read: () => Resource;
   };
+  type: AnnouncementType;
 }
 
-const AnnounceList = ({ resource }: AnnounceListProps) => {
+const AnnounceList = ({ resource, type }: AnnounceListProps) => {
   const announceList: Resource = resource.read();
-
   if (announceList === null || announceList instanceof Error) {
-    return null;
+    return <></>;
   }
-  const { 고정: pinned, 일반: normal } = announceList as AnnounceItemList;
+
+  const { 고정: pinnedAnnouncement, 일반: normalAnnouncemnet } =
+    announceList as AnnounceItemList;
 
   return (
     <>
-      {pinned.map((announce, idx) => (
-        <div key={idx}>
-          <AnnounceCard {...announce} pinned={true} />
-        </div>
-      ))}
-      {normal.map((announce, idx) => (
-        <div key={idx}>
-          <AnnounceCard {...announce} />
-        </div>
-      ))}
+      <BoundaryLine />
+      {type === ANNOUNCEMENT_TYPE.NORMAL &&
+        normalAnnouncemnet.map((announce, idx) => (
+          <Fragment key={idx}>
+            <AnnounceCard {...announce} />
+          </Fragment>
+        ))}
+      {type === ANNOUNCEMENT_TYPE.PINNED &&
+        pinnedAnnouncement.map((announce, idx) => (
+          <Fragment key={idx}>
+            <AnnounceCard {...announce} />
+          </Fragment>
+        ))}
+      {type === ANNOUNCEMENT_TYPE.SEARCH && (
+        <AnnounceSearchList
+          announceList={[...pinnedAnnouncement, ...normalAnnouncemnet]}
+        />
+      )}
     </>
   );
 };
 
 export default AnnounceList;
+
+const BoundaryLine = styled.div`
+  border-bottom: 1px solid ${THEME.TEXT.BLACK};
+`;

--- a/src/components/Card/AnnounceCard/index.test.tsx
+++ b/src/components/Card/AnnounceCard/index.test.tsx
@@ -1,4 +1,5 @@
 import http from '@apis/http';
+import MajorProvider from '@components/MajorProvider';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AnnounceItemList } from '@type/announcement';
@@ -34,7 +35,12 @@ describe('공지사항 카드 컴포넌트 테스트', () => {
     const { 고정, 일반 } = announceList;
 
     일반.forEach(async (annouce) => {
-      render(<AnnounceCard {...annouce} />, { wrapper: MemoryRouter });
+      render(
+        <MajorProvider>
+          <AnnounceCard {...annouce} />
+        </MajorProvider>,
+        { wrapper: MemoryRouter },
+      );
     });
 
     const annouceCards = screen.getAllByTestId('card');

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -2,38 +2,33 @@ import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { AnnounceItem } from '@type/announcement';
+import openLink from '@utils/router/openLink';
 
 interface AnnounceCardProps extends AnnounceItem {
-  Author?: string;
+  author?: string;
 }
 
 const AnnounceCard = ({
   title,
   link,
   uploadDate,
-  Author,
+  author,
 }: AnnounceCardProps) => {
   const { major } = useMajor();
-
-  const onClick = () => {
-    window.open(link, '_blank');
-  };
 
   uploadDate = uploadDate.slice(2);
 
   return (
-    <Card onClick={onClick} data-testid="card">
+    <Card onClick={() => openLink(link)} data-testid="card">
       <ContentContainer>
-        <FlexWrapper>
-          <AnnounceTitle>{title}</AnnounceTitle>
-        </FlexWrapper>
-        <SubTitle>
+        <AnnounceTitle>{title}</AnnounceTitle>
+        <SubContent>
           <AnnounceDate>20{uploadDate}</AnnounceDate>
-          <VertialSeparator />
-          <Source>{Author ? Author : major}</Source>
-        </SubTitle>
+          <VertialBoundaryLine />
+          <Source>{author ? author : major}</Source>
+        </SubContent>
       </ContentContainer>
-      <Contour />
+      <HorizonBoundaryLine />
     </Card>
   );
 };
@@ -45,28 +40,7 @@ const Card = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-
   color: ${THEME.TEXT.BLACK};
-`;
-
-const ContentContainer = styled.div`
-  padding: 20px 0 20px 0;
-  display: flex;
-  line-height: 1.5;
-  flex-direction: column;
-`;
-
-const AnnounceTitle = styled.span`
-  display: flex;
-  align-items: center;
-  flex: 9;
-  font-size: 16px;
-  font-weight: 500;
-  margin-left: 28px;
-
-  &: hover {
-    cursor: pointer;
-  }
 
   transition: 0.3s;
   &:active {
@@ -75,7 +49,24 @@ const AnnounceTitle = styled.span`
   }
 `;
 
-const VertialSeparator = styled.div`
+const ContentContainer = styled.div`
+  padding: 20px 0 20px 0;
+  display: flex;
+  line-height: 1.5;
+  flex-direction: column;
+
+  gap: 10px;
+`;
+
+const AnnounceTitle = styled.span`
+  display: flex;
+  align-items: center;
+  flex: 9;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+const VertialBoundaryLine = styled.div`
   border-left: 1px solid gray;
   height: 12px;
   margin: 0 5px;
@@ -89,20 +80,13 @@ const AnnounceDate = styled.span`
   padding-right: 5px;
 `;
 
-const Contour = styled.div`
-  width: 90%;
-  margin: 0 auto;
+const HorizonBoundaryLine = styled.div`
   border-bottom: 1px solid ${THEME.BACKGROUND};
 `;
 
-const FlexWrapper = styled.div`
-  display: flex;
-`;
-
-const SubTitle = styled.div`
+const SubContent = styled.div`
   display: flex;
   align-items: center;
-  padding: 10px 0 0 28px;
 `;
 
 const Source = styled.div`

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -1,6 +1,7 @@
 import Icon from '@components/Icon';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import useMajor from '@hooks/useMajor';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { AnnounceItem } from '@type/announcement';
 
@@ -14,6 +15,8 @@ const AnnounceCard = ({
   uploadDate,
   pinned = false,
 }: AnnounceCardProps) => {
+  const { major } = useMajor();
+
   const onClick = () => {
     window.open(link, '_blank');
   };
@@ -23,17 +26,18 @@ const AnnounceCard = ({
   return (
     <Card onClick={onClick} data-testid="card">
       <ContentContainer>
-        {pinned && <Icon kind="speaker" color={THEME.PRIMARY} />}
-        <AnnounceTitle pinned={pinned}>{title}</AnnounceTitle>
-        <VertialSeparator
-          css={css`
-            border-left: 1px solid gray;
-            height: 12px;
-            margin: 0 5px;
-          `}
-        />
-        <AnnounceDate>{uploadDate}</AnnounceDate>
+        <FlexWrapper>
+          {pinned && <Icon kind="speaker" color={THEME.PRIMARY} />}
+          <AnnounceTitle pinned={pinned}>{title}</AnnounceTitle>
+        </FlexWrapper>
+        <SubTitle>
+          <VertialSeparator />
+          <Source>{major}</Source>
+          <VertialSeparator />
+          <AnnounceDate>{uploadDate}</AnnounceDate>
+        </SubTitle>
       </ContentContainer>
+      <Contour />
     </Card>
   );
 };
@@ -41,8 +45,8 @@ const AnnounceCard = ({
 export default AnnounceCard;
 
 const Card = styled.div`
-  height: 28px;
-  padding: 10px;
+  min-height: 28px;
+  padding: 4px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -52,18 +56,17 @@ const Card = styled.div`
 
 const ContentContainer = styled.div`
   display: flex;
-  align-items: center;
+  line-height: 1.5;
+  flex-direction: column;
 `;
 
 const AnnounceTitle = styled.span<{ pinned: boolean }>`
+  display: flex;
+  align-items: center;
   flex: 9;
   font-size: 15px;
   font-weight: ${({ pinned }) => (pinned ? 'bold' : 500)};
   margin-left: ${({ pinned }) => (pinned ? '' : '28px')};
-
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 
   &: hover {
     cursor: pointer;
@@ -86,8 +89,29 @@ const AnnounceDate = styled.span`
   flex: 1;
   font-size: 10px;
   font-weight: bold;
-  text-align: end;
   white-space: nowrap;
 
   color: ${THEME.TEXT.GRAY};
+`;
+
+const Contour = styled.div`
+  width: 90%;
+  padding-top: 5px;
+  margin: 0 auto;
+  border-bottom: 1px solid ${THEME.BACKGROUND};
+`;
+
+const FlexWrapper = styled.div`
+  display: flex;
+`;
+
+const SubTitle = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 5px 0 0 26px;
+`;
+
+const Source = styled.div`
+  font-size: 11px;
+  color: gray;
 `;

--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -1,19 +1,17 @@
-import Icon from '@components/Icon';
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useMajor from '@hooks/useMajor';
 import { THEME } from '@styles/ThemeProvider/theme';
 import { AnnounceItem } from '@type/announcement';
 
 interface AnnounceCardProps extends AnnounceItem {
-  pinned?: boolean;
+  Author?: string;
 }
 
 const AnnounceCard = ({
   title,
   link,
   uploadDate,
-  pinned = false,
+  Author,
 }: AnnounceCardProps) => {
   const { major } = useMajor();
 
@@ -27,14 +25,12 @@ const AnnounceCard = ({
     <Card onClick={onClick} data-testid="card">
       <ContentContainer>
         <FlexWrapper>
-          {pinned && <Icon kind="speaker" color={THEME.PRIMARY} />}
-          <AnnounceTitle pinned={pinned}>{title}</AnnounceTitle>
+          <AnnounceTitle>{title}</AnnounceTitle>
         </FlexWrapper>
         <SubTitle>
+          <AnnounceDate>20{uploadDate}</AnnounceDate>
           <VertialSeparator />
-          <Source>{major}</Source>
-          <VertialSeparator />
-          <AnnounceDate>{uploadDate}</AnnounceDate>
+          <Source>{Author ? Author : major}</Source>
         </SubTitle>
       </ContentContainer>
       <Contour />
@@ -45,8 +41,7 @@ const AnnounceCard = ({
 export default AnnounceCard;
 
 const Card = styled.div`
-  min-height: 28px;
-  padding: 4px;
+  min-height: 50px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -55,18 +50,19 @@ const Card = styled.div`
 `;
 
 const ContentContainer = styled.div`
+  padding: 20px 0 20px 0;
   display: flex;
   line-height: 1.5;
   flex-direction: column;
 `;
 
-const AnnounceTitle = styled.span<{ pinned: boolean }>`
+const AnnounceTitle = styled.span`
   display: flex;
   align-items: center;
   flex: 9;
-  font-size: 15px;
-  font-weight: ${({ pinned }) => (pinned ? 'bold' : 500)};
-  margin-left: ${({ pinned }) => (pinned ? '' : '28px')};
+  font-size: 16px;
+  font-weight: 500;
+  margin-left: 28px;
 
   &: hover {
     cursor: pointer;
@@ -86,17 +82,15 @@ const VertialSeparator = styled.div`
 `;
 
 const AnnounceDate = styled.span`
-  flex: 1;
-  font-size: 10px;
-  font-weight: bold;
+  font-size: 13px;
   white-space: nowrap;
 
   color: ${THEME.TEXT.GRAY};
+  padding-right: 5px;
 `;
 
 const Contour = styled.div`
   width: 90%;
-  padding-top: 5px;
   margin: 0 auto;
   border-bottom: 1px solid ${THEME.BACKGROUND};
 `;
@@ -108,10 +102,11 @@ const FlexWrapper = styled.div`
 const SubTitle = styled.div`
   display: flex;
   align-items: center;
-  padding: 5px 0 0 26px;
+  padding: 10px 0 0 28px;
 `;
 
 const Source = styled.div`
-  font-size: 11px;
+  font-size: 13px;
   color: gray;
+  padding-left: 5px;
 `;

--- a/src/components/Card/InformCard/index.test.tsx
+++ b/src/components/Card/InformCard/index.test.tsx
@@ -43,12 +43,13 @@ const setMajorMock = (isRender: boolean) => {
 
   jest.mock('react', () => ({
     ...jest.requireActual('react'),
-    useState: () => [mockMajor, mockSetMajor],
+    useState: () => [mockMajor, mockSetMajor, graduationLink],
   }));
 
   return {
     major: mockMajor,
     setMajor: mockSetMajor,
+    graduationLink,
   };
 };
 

--- a/src/components/Card/InformCard/index.tsx
+++ b/src/components/Card/InformCard/index.tsx
@@ -23,8 +23,9 @@ const InformCard = ({
 }: InformCardProps) => {
   const { major } = useMajor();
   const { routerTo } = useRouter();
-  const routerToMajorDecision = () => routerTo('/major-decision');
   const { openModal, closeModal } = useModals();
+
+  const routeToMajorDecisionPage = () => routerTo('/major-decision');
 
   const handleMajorModal = () => {
     if (!majorRequired || major) {
@@ -38,7 +39,7 @@ const InformCard = ({
       onClose: () => closeModal(modals.alert),
       routerTo: () => {
         closeModal(modals.alert);
-        routerToMajorDecision();
+        routeToMajorDecisionPage();
       },
     });
   };
@@ -46,40 +47,13 @@ const InformCard = ({
   return (
     <>
       <Card data-testid="card" onClick={handleMajorModal}>
-        <Wrapper>
-          <div
-            css={css`
-              display: flex;
-              border-radius: 50%;
-              background-color: ${THEME.PRIMARY};
-              height: 45px;
-              width: 45px;
-              justify-content: center;
-              align-items: center;
-            `}
-          >
-            <Icon kind={icon} color={THEME.TEXT.WHITE} />
-          </div>
-        </Wrapper>
-        <Wrapper>
-          <span
-            css={css`
-              font-size: 13px;
-            `}
-          >
-            {title}
-          </span>
-          <span
-            css={css`
-              font-size: 15px;
-              margin: auto 0;
-              font-weight: bold;
-              color: ${THEME.TEXT.BLACK};
-            `}
-          >
-            {title} 보러가기
-          </span>
-        </Wrapper>
+        <IconContainer>
+          <Icon kind={icon} color={THEME.TEXT.WHITE} />
+        </IconContainer>
+        <TextContainer>
+          <span>{title}</span>
+          <span>{title} 보러가기</span>
+        </TextContainer>
       </Card>
     </>
   );
@@ -89,33 +63,38 @@ export default InformCard;
 
 const Card = styled.div`
   display: flex;
-  flex-direction: row;
+  align-items: center;
   padding: 3% 1% 2% 0;
-  color: ${THEME.TEXT.GRAY};
-  height: 70px;
-
-  & > svg {
-    margin: 10px 0;
-  }
-  cursor: pointer;
+  height: 4rem;
 
   transition: all 0.2s ease-in-out;
 
-  &:active {
-    transform: scale(0.95);
-    opacity: 0.6;
+  span:nth-of-type(1) {
+    font-size: 12px;
+    color: ${THEME.TEXT.GRAY};
+  }
+
+  span:nth-of-type(2) {
+    font-size: 16px;
+    font-weight: bold;
+    color: ${THEME.TEXT.BLACK};
   }
 `;
 
-const Wrapper = styled.div`
-  &:first-of-type {
-    display: flex;
-    align-items: center;
-  }
+const TextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
 
-  &:nth-of-type(2) {
-    display: flex;
-    flex-direction: column;
-    padding: 4% 0 3% 3%;
-  }
+const IconContainer = styled.div`
+  height: 45px;
+  width: 45px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-right: 10px;
+
+  border-radius: 50%;
+  background-color: ${THEME.PRIMARY};
 `;

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -67,7 +67,7 @@ const CarouselContainer = styled.div`
   padding: 1rem 0 1rem;
   width: 100%;
   margin: 0 auto;
-  &: hover {
+  &:hover {
     cursor: pointer;
   }
 `;
@@ -100,7 +100,7 @@ const Button = styled.button`
   border-radius: 0.5rem;
   margin-top: 1rem;
 
-  &: hover {
+  &:hover {
     cursor: pointer;
   }
 `;

--- a/src/components/List/DepartmentList/index.test.tsx
+++ b/src/components/List/DepartmentList/index.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@hooks/useModals', () => {
 });
 
 describe.skip('학과선택 테스트', () => {
+  const mockGraduationLink = 'https://ce.pknu.ac.kr/ce/2889';
   const mockUseMajor = useMajor as jest.MockedFunction<typeof useMajor>;
   const mockSetMajor = jest.fn();
 
@@ -38,6 +39,7 @@ describe.skip('학과선택 테스트', () => {
     mockUseMajor.mockReturnValue({
       setMajor: mockSetMajor,
       major: '컴퓨터공학과',
+      graduationLink: mockGraduationLink,
     });
   });
 

--- a/src/components/MajorProvider/index.tsx
+++ b/src/components/MajorProvider/index.tsx
@@ -1,5 +1,12 @@
+import http from '@apis/http';
 import MajorContext from '@contexts/major';
+import { AxiosResponse } from 'axios';
 import React, { useEffect, useState } from 'react';
+
+interface GraduationLink {
+  department: string;
+  link: string | null;
+}
 
 interface MajorProviderProps {
   children: React.ReactNode;
@@ -7,30 +14,28 @@ interface MajorProviderProps {
 
 const MajorProvider = ({ children }: MajorProviderProps) => {
   const [major, setMajor] = useState<string | null>(null);
+  const [graduationLink, setGraduationLink] = useState<string | null>('');
 
   useEffect(() => {
     const storedMajor = localStorage.getItem('major');
-
     if (!storedMajor) return;
     setMajor(storedMajor);
   }, []);
 
   useEffect(() => {
-    const handleStorageChange = (event: StorageEvent) => {
-      if (event.key === 'major') {
-        const storedMajor = event.newValue;
-        if (storedMajor !== null) setMajor(storedMajor);
-      }
-    };
-    window.addEventListener('storage', handleStorageChange);
+    if (!major) return;
 
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, []);
+    (async () => {
+      const response: AxiosResponse<GraduationLink> = await http.get(
+        `/api/graduation?major=${major}`,
+      );
+      const graduationLink = response.data.link;
+      setGraduationLink(graduationLink);
+    })();
+  }, [major]);
 
   return (
-    <MajorContext.Provider value={{ major, setMajor }}>
+    <MajorContext.Provider value={{ major, setMajor, graduationLink }}>
       {children}
     </MajorContext.Provider>
   );

--- a/src/components/Modal/ConfirmModal/index.tsx
+++ b/src/components/Modal/ConfirmModal/index.tsx
@@ -41,8 +41,8 @@ const ConfirmModal = ({
                 justify-content: center;
               `}
             >
-              <Button onClick={onConfirmButtonClick}>네!</Button>
               <Button onClick={onCancelButtonClick}>아니오</Button>
+              <Button onClick={onConfirmButtonClick}>네!</Button>
             </div>
           </>
         </Modal>

--- a/src/constants/announcement.ts
+++ b/src/constants/announcement.ts
@@ -1,0 +1,15 @@
+export const ANNOUNCEMENT_TITLE = {
+  SCHOOL: '학교 공지사항',
+  MAROR: '학과 공지사항',
+};
+
+export const ANNOUNCEMENT_CATEGORY = {
+  SCHOOL: 'school',
+  MAJOR: 'major',
+} as const;
+
+export const ANNOUNCEMENT_TYPE = {
+  NORMAL: 'normal',
+  PINNED: 'pinned',
+  SEARCH: 'search',
+} as const;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,14 @@
+type Category = 'school' | 'major';
+
+const PATH = {
+  SCHOOL_ANNOUNCEMENT: '/school/:type',
+  MAJOR_ANNOUNCEMENT: '/major/:type',
+  NORMAL_ANNOUNCEMENT: (category: Category) =>
+    `/announcement/${category}/normal`,
+  PINNED_ANNOUNCEMENT: (category: Category) =>
+    `/announcement/${category}/pinned`,
+  SEARCH_ANNOUNCEMENT: (category: Category, keyword: string) =>
+    `/announcement/${category}/search?q=${keyword}`,
+} as const;
+
+export default PATH;

--- a/src/constants/placeholder-message.ts
+++ b/src/constants/placeholder-message.ts
@@ -1,6 +1,7 @@
 const PLCACEHOLDER_MESSAGES = {
   SUGGESTION: '건의사항을 5글자 이상 남겨주세요',
   SEARCH_BUILDING: '건물번호 또는 건물이름을 검색해주세요',
+  SEARCH_TITLE: '제목을 검색하세요',
 } as const;
 
 export default PLCACEHOLDER_MESSAGES;

--- a/src/constants/toast-message.ts
+++ b/src/constants/toast-message.ts
@@ -1,7 +1,8 @@
 const TOAST_MESSAGES = {
   OUT_OF_BOUNDARY: '학교 외부로 이동할 수 없어요!',
   OUT_OF_SHOOL: '학교 밖에서는 내 위치 정보를 제공하지 않아요!',
-  SHARE_LOCATION: '위치 정보를 공유해 주세요.',
+  SHARE_LOCATION: '위치 정보를 공유해 주세요',
+  SEARCH_KEYWORD: '검색어를 입력해주세요',
 } as const;
 
 export default TOAST_MESSAGES;

--- a/src/contexts/major.ts
+++ b/src/contexts/major.ts
@@ -4,6 +4,7 @@ import { createContext } from 'react';
 interface MajorState {
   major: Major;
   setMajor: React.Dispatch<React.SetStateAction<Major>>;
+  graduationLink: string | null;
 }
 
 const MajorContext = createContext<MajorState | null>(null);

--- a/src/pages/Announcement/components/AnnounceContainer.tsx
+++ b/src/pages/Announcement/components/AnnounceContainer.tsx
@@ -1,0 +1,120 @@
+import fetchAnnounceList from '@apis/Suspense/fetch-announce-list';
+import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
+import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
+import { ANNOUNCEMENT_TYPE } from '@constants/announcement';
+import PATH from '@constants/path';
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+import useRouter from '@hooks/useRouter';
+import {
+  AnnounceItemList,
+  AnnouncementCategory,
+  AnnouncementType,
+} from '@type/announcement';
+import React, { Suspense, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import AnnounceSearch from './AnnounceSearch';
+import AnnounceTypeButtons from './AnnounceTypeButtons';
+
+interface AnnounceContainerProps {
+  title: string;
+  category: AnnouncementCategory;
+  endPoint: string | null;
+}
+
+const AnnounceContainer = ({
+  title,
+  category,
+  endPoint,
+}: AnnounceContainerProps) => {
+  const { type } = useParams();
+  if (!type) return <></>;
+
+  const { routerTo } = useRouter();
+
+  const showNormalAnnouncement = () =>
+    routerTo(PATH.NORMAL_ANNOUNCEMENT(category));
+  const showPinnedAnnouncement = () =>
+    routerTo(PATH.PINNED_ANNOUNCEMENT(category));
+
+  const resource = useMemo(
+    () => fetchAnnounceList<AnnounceItemList>(endPoint),
+    [],
+  );
+
+  return (
+    <Container>
+      <AnnounceTitle>{title}</AnnounceTitle>
+      <AnnounceSearch category={category} />
+      <ButtonContainer>
+        <AnnounceTypeButtons
+          type="일반"
+          onClick={showNormalAnnouncement}
+          isActive={type === ANNOUNCEMENT_TYPE.NORMAL}
+        />
+        <AnnounceTypeButtons
+          type="고정"
+          onClick={showPinnedAnnouncement}
+          isActive={type === ANNOUNCEMENT_TYPE.PINNED}
+        />
+      </ButtonContainer>
+      <AnnounceListContainer type={type as AnnouncementType}>
+        <Suspense fallback={<AnnounceCardSkeleton length={30} />}>
+          <AnnounceList resource={resource} type={type as AnnouncementType} />
+        </Suspense>
+      </AnnounceListContainer>
+    </Container>
+  );
+};
+
+export default AnnounceContainer;
+
+const Container = styled.div`
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+
+  row-gap: 15px;
+  padding: 10px;
+`;
+
+const AnnounceTitle = styled.span`
+  margin-top: 1rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  column-gap: 10px;
+`;
+
+const getAnimationType = (type: AnnouncementType) => {
+  if (type === 'search') return 'none';
+  return type === 'normal' ? AnnounceSlideLeft : AnnounceSlideRight;
+};
+
+const AnnounceListContainer = styled.div<{ type: AnnouncementType }>`
+  width: 100%;
+  overflow: hidden;
+  animation: ${({ type }) => getAnimationType(type)} 0.3s forwards;
+`;
+
+const AnnounceSlideRight = keyframes`
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0%);
+  }
+`;
+
+const AnnounceSlideLeft = keyframes`
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0%);
+  }
+`;

--- a/src/pages/Announcement/components/AnnounceNotFound.tsx
+++ b/src/pages/Announcement/components/AnnounceNotFound.tsx
@@ -1,0 +1,32 @@
+import Icon from '@components/Icon';
+import styled from '@emotion/styled';
+import { THEME } from '@styles/ThemeProvider/theme';
+import React from 'react';
+
+interface AnnounceNotFoundProps {
+  keyword: string;
+}
+
+const AnnounceNotFound = ({ keyword }: AnnounceNotFoundProps) => {
+  return (
+    <Container>
+      <Icon kind="warning" color={THEME.TEXT.GRAY} />
+      <Title>{`"${keyword}"`}에 관한 공지사항이 없습니다.</Title>
+    </Container>
+  );
+};
+
+export default AnnounceNotFound;
+
+const Container = styled.div`
+  height: 20rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Title = styled.span`
+  color: ${THEME.TEXT.GRAY};
+`;

--- a/src/pages/Announcement/components/AnnounceSearch.tsx
+++ b/src/pages/Announcement/components/AnnounceSearch.tsx
@@ -1,0 +1,86 @@
+import Icon from '@components/Icon';
+import PATH from '@constants/path';
+import PLCACEHOLDER_MESSAGES from '@constants/placeholder-message';
+import TOAST_MESSAGES from '@constants/toast-message';
+import styled from '@emotion/styled';
+import useRouter from '@hooks/useRouter';
+import useToasts from '@hooks/useToast';
+import React, { useRef } from 'react';
+
+interface AnnounceSearchProps {
+  category: 'school' | 'major';
+}
+
+const AnnounceSearch = ({ category }: AnnounceSearchProps) => {
+  const { routerTo } = useRouter();
+  const { addToast } = useToasts();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (!inputRef.current) return;
+    e.preventDefault();
+    if (inputRef.current.value.length === 0) {
+      addToast(TOAST_MESSAGES.SEARCH_KEYWORD);
+      return;
+    }
+
+    routerTo(PATH.SEARCH_ANNOUNCEMENT(category, inputRef.current.value));
+    inputRef.current.value = '';
+    inputRef.current.blur();
+  };
+
+  return (
+    <div>
+      <StyledForm onSubmit={handleSubmit}>
+        <StyledInput
+          ref={inputRef}
+          type="text"
+          placeholder={PLCACEHOLDER_MESSAGES.SEARCH_TITLE}
+        />
+        <StyledIconWrapper onClick={() => handleSubmit}>
+          <Icon kind="search" color="#7A9DD3" />
+        </StyledIconWrapper>
+      </StyledForm>
+    </div>
+  );
+};
+
+export default AnnounceSearch;
+
+const StyledForm = styled.form`
+  display: flex;
+  position: relative;
+`;
+
+const StyledInput = styled.input`
+  -webkit-appearance: none;
+  appearance: none;
+
+  width: 100%;
+  padding: 10px;
+  border: 0;
+  border-radius: 15px;
+  background-color: #7a9dd30f;
+  color: #7a9dd366;
+  font-size: 14px;
+  text-indent: 5px;
+
+  &::placeholder {
+    color: #7a9dd366;
+    font-size: 14px;
+  }
+  box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.15);
+  &:focus {
+    outline: none;
+    box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.2);
+  }
+`;
+
+const StyledIconWrapper = styled.button`
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: transparent;
+`;

--- a/src/pages/Announcement/components/AnnounceSearchList.tsx
+++ b/src/pages/Announcement/components/AnnounceSearchList.tsx
@@ -1,10 +1,9 @@
 import AnnounceCard from '@components/Card/AnnounceCard';
-import Icon from '@components/Icon';
-import styled from '@emotion/styled';
-import { THEME } from '@styles/ThemeProvider/theme';
 import { AnnounceItem } from '@type/announcement';
 import React, { Fragment } from 'react';
 import { useLocation } from 'react-router-dom';
+
+import AnnounceNotFound from './AnnounceNotFound';
 
 interface AnnounceSearchProps {
   announceList: AnnounceItem[];
@@ -17,7 +16,7 @@ const AnnounceSearchList = ({ announceList }: AnnounceSearchProps) => {
   const searchResult = announceList.filter((announceItem) =>
     announceItem.title.includes(searchKeyword),
   );
-  const hasSearchResult = () => searchResult.length === 0;
+  const hasSearchResult = () => searchResult.length !== 0;
 
   return (
     <Fragment>
@@ -28,28 +27,10 @@ const AnnounceSearchList = ({ announceList }: AnnounceSearchProps) => {
           </Fragment>
         ))
       ) : (
-        <AnnounceNotFound>
-          <Icon kind="warning" color={THEME.TEXT.GRAY} />
-          <NotFoundTitle>
-            {`"${searchKeyword}"`}에 관한 공지사항이 없습니다.
-          </NotFoundTitle>
-        </AnnounceNotFound>
+        <AnnounceNotFound keyword={searchKeyword} />
       )}
     </Fragment>
   );
 };
 
 export default AnnounceSearchList;
-
-const AnnounceNotFound = styled.div`
-  height: 20rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-`;
-
-const NotFoundTitle = styled.span`
-  color: ${THEME.TEXT.GRAY};
-`;

--- a/src/pages/Announcement/components/AnnounceSearchList.tsx
+++ b/src/pages/Announcement/components/AnnounceSearchList.tsx
@@ -1,0 +1,55 @@
+import AnnounceCard from '@components/Card/AnnounceCard';
+import Icon from '@components/Icon';
+import styled from '@emotion/styled';
+import { THEME } from '@styles/ThemeProvider/theme';
+import { AnnounceItem } from '@type/announcement';
+import React, { Fragment } from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface AnnounceSearchProps {
+  announceList: AnnounceItem[];
+}
+
+const AnnounceSearchList = ({ announceList }: AnnounceSearchProps) => {
+  const { search } = useLocation();
+
+  const searchKeyword = decodeURI(search.split('=')[1]);
+  const searchResult = announceList.filter((announceItem) =>
+    announceItem.title.includes(searchKeyword),
+  );
+  const hasSearchResult = () => searchResult.length === 0;
+
+  return (
+    <Fragment>
+      {hasSearchResult() ? (
+        searchResult.map((announce, idx) => (
+          <Fragment key={idx}>
+            <AnnounceCard {...announce} />
+          </Fragment>
+        ))
+      ) : (
+        <AnnounceNotFound>
+          <Icon kind="warning" color={THEME.TEXT.GRAY} />
+          <NotFoundTitle>
+            {`"${searchKeyword}"`}에 관한 공지사항이 없습니다.
+          </NotFoundTitle>
+        </AnnounceNotFound>
+      )}
+    </Fragment>
+  );
+};
+
+export default AnnounceSearchList;
+
+const AnnounceNotFound = styled.div`
+  height: 20rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;
+
+const NotFoundTitle = styled.span`
+  color: ${THEME.TEXT.GRAY};
+`;

--- a/src/pages/Announcement/components/AnnounceTypeButtons.tsx
+++ b/src/pages/Announcement/components/AnnounceTypeButtons.tsx
@@ -1,0 +1,35 @@
+import Button from '@components/Button';
+import { css } from '@emotion/react';
+import { THEME } from '@styles/ThemeProvider/theme';
+import React from 'react';
+
+interface AnnounceTypeButtonsProps {
+  type: '일반' | '고정';
+  isActive: boolean;
+  onClick: () => void;
+}
+
+const AnnounceTypeButtons = ({
+  type,
+  isActive,
+  onClick,
+}: AnnounceTypeButtonsProps) => {
+  return (
+    <Button
+      css={css`
+        margin: 0px;
+        height: 2rem;
+        width: 4rem;
+        border-radius: 4rem;
+        font-weight: normal;
+        background-color: ${isActive ? THEME.BUTTON.BLUE : THEME.BUTTON.GRAY};
+        color: ${isActive ? THEME.TEXT.WHITE : THEME.TEXT.GRAY};
+      `}
+      onClick={onClick}
+    >
+      {type}
+    </Button>
+  );
+};
+
+export default AnnounceTypeButtons;

--- a/src/pages/Announcement/components/index.ts
+++ b/src/pages/Announcement/components/index.ts
@@ -1,0 +1,4 @@
+export { default as AnnounceContainer } from './AnnounceContainer';
+export { default as AnnounceSearch } from './AnnounceSearch';
+export { default as AnnounceSearchList } from './AnnounceSearchList';
+export { default as AnnounceTypeButtons } from './AnnounceTypeButtons';

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -1,136 +1,41 @@
-import fetchAnnounceList from '@apis/Suspense/fetch-announce-list';
-import Button from '@components/Button';
-import AnnounceList from '@components/Card/AnnounceCard/AnnounceList';
-import AnnounceCardSkeleton from '@components/Card/AnnounceCard/Skeleton';
-import { MODAL_BUTTON_MESSAGE, MODAL_MESSAGE } from '@constants/modal-messages';
-import { css, keyframes } from '@emotion/react';
-import styled from '@emotion/styled';
+import {
+  ANNOUNCEMENT_CATEGORY,
+  ANNOUNCEMENT_TITLE,
+} from '@constants/announcement';
+import PATH from '@constants/path';
 import useMajor from '@hooks/useMajor';
-import useModals, { modals } from '@hooks/useModals';
-import useRouter from '@hooks/useRouter';
-import { THEME } from '@styles/ThemeProvider/theme';
-import { Suspense } from 'react';
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+
+import { AnnounceContainer } from './components';
 
 const Announcement = () => {
   const { major } = useMajor();
-  const { routerTo } = useRouter();
-  const { openModal, closeModal } = useModals();
-
-  const announceKeyword = decodeURI(window.location.pathname.split('/')[2]);
-  const isActiveSchoolAnnouncement = () => announceKeyword === 'undefined';
-
-  const routerToMajorDecision = () => routerTo('/major-decision');
-  const routerToSchoolAnnouncement = () => routerTo('');
-  const routerToMajorAnnouncement = () => {
-    if (!major) {
-      openModal<typeof modals.alert>(modals.alert, {
-        message: MODAL_MESSAGE.ALERT.SET_MAJOR,
-        buttonMessage: MODAL_BUTTON_MESSAGE.SET_MAJOR,
-        iconKind: 'plus',
-        onClose: () => closeModal(modals.alert),
-        routerTo: () => {
-          closeModal(modals.alert);
-          routerToMajorDecision();
-        },
-      });
-    }
-    routerTo(`${major}`);
-  };
 
   return (
-    <Container>
-      <ButtonContainer>
-        <Button
-          onClick={routerToSchoolAnnouncement}
-          css={css`
-            margin: 0px;
-            height: 55px;
-            border-radius: 0px;
-            background-color: ${THEME.TEXT.WHITE};
-            color: ${isActiveSchoolAnnouncement()
-              ? THEME.PRIMARY
-              : THEME.TEXT.BLACK};
-          `}
-        >
-          학교 공지사항
-        </Button>
-        <Button
-          onClick={() => routerToMajorAnnouncement()}
-          css={css`
-            margin: 0px;
-            height: 55px;
-            border-radius: 0px;
-            background-color: ${THEME.TEXT.WHITE};
-            color: ${isActiveSchoolAnnouncement()
-              ? THEME.TEXT.BLACK
-              : THEME.PRIMARY};
-          `}
-        >
-          학과 공지사항
-        </Button>
-        <ButtonBottomBar isActiveSchool={isActiveSchoolAnnouncement()} />
-      </ButtonContainer>
-      <AnnounceContainer isActiveSchool={isActiveSchoolAnnouncement()}>
-        <Suspense fallback={<AnnounceCardSkeleton length={30} />}>
-          <AnnounceList
-            resource={fetchAnnounceList(
-              isActiveSchoolAnnouncement() ? '' : announceKeyword,
-            )}
+    <Routes>
+      <Route
+        path={PATH.SCHOOL_ANNOUNCEMENT}
+        element={
+          <AnnounceContainer
+            title={ANNOUNCEMENT_TITLE.SCHOOL}
+            category={ANNOUNCEMENT_CATEGORY.SCHOOL}
+            endPoint=""
           />
-        </Suspense>
-      </AnnounceContainer>
-    </Container>
+        }
+      />
+      <Route
+        path={PATH.MAJOR_ANNOUNCEMENT}
+        element={
+          <AnnounceContainer
+            title={ANNOUNCEMENT_TITLE.MAROR}
+            category={ANNOUNCEMENT_CATEGORY.MAJOR}
+            endPoint={major}
+          />
+        }
+      />
+    </Routes>
   );
 };
 
 export default Announcement;
-
-const Container = styled.div`
-  overflow-x: hidden;
-`;
-
-const ButtonContainer = styled.div`
-  width: 100%;
-  display: flex;
-  position: relative;
-  overflow-x: none;
-`;
-
-const ButtonBottomBar = styled.span<{ isActiveSchool: boolean }>`
-  &:before {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: ${({ isActiveSchool }) => (isActiveSchool ? '0' : '50%')};
-    width: 50%;
-    height: 3px;
-    background-color: ${THEME.PRIMARY};
-    transition: left 0.3s ease-in-out;
-  }
-`;
-
-const AnnounceContainer = styled.div<{ isActiveSchool: boolean }>`
-  width: 100%;
-  overflow: hidden;
-  animation: ${({ isActiveSchool }) =>
-      isActiveSchool ? AnnounceSlideLeft : AnnounceSlideRight}
-    0.3s forwards;
-`;
-
-const AnnounceSlideRight = keyframes`
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(0%);
-  }
-`;
-
-const AnnounceSlideLeft = keyframes`
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0%);
-  }
-`;

--- a/src/pages/Home/Home.test.tsx
+++ b/src/pages/Home/Home.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 
 import Home from './index';
 
-describe('App 컴포넌트 테스트', () => {
+describe('Home Page 컴포넌트 테스트', () => {
   it('페이지에 공지사항 및 졸업요건 컴포넌트가 렌더링된다.', () => {
     render(
       <MajorProvider>
@@ -18,7 +18,7 @@ describe('App 컴포넌트 테스트', () => {
         wrapper: MemoryRouter,
       },
     );
-    const notificationText = screen.getByText('공지사항');
+    const notificationText = screen.getByText('학교 공지사항');
     expect(notificationText).toBeInTheDocument();
 
     const requirementText = screen.getByText('졸업요건');

--- a/src/pages/Home/components/InformCardList.tsx
+++ b/src/pages/Home/components/InformCardList.tsx
@@ -1,0 +1,37 @@
+import InformCard from '@components/Card/InformCard';
+import { ANNOUNCEMENT_TITLE } from '@constants/announcement';
+import PATH from '@constants/path';
+import useMajor from '@hooks/useMajor';
+import useRouter from '@hooks/useRouter';
+import openLink from '@utils/router/openLink';
+import React from 'react';
+
+const InformCardList = () => {
+  const { graduationLink } = useMajor();
+  const { routerTo } = useRouter();
+
+  return (
+    <>
+      <InformCard
+        icon="notification"
+        title={ANNOUNCEMENT_TITLE.SCHOOL}
+        majorRequired={false}
+        onClick={() => routerTo(PATH.NORMAL_ANNOUNCEMENT('school'))}
+      />
+      <InformCard
+        icon="notification"
+        title={ANNOUNCEMENT_TITLE.MAROR}
+        majorRequired={true}
+        onClick={() => routerTo(PATH.NORMAL_ANNOUNCEMENT('major'))}
+      />
+      <InformCard
+        icon="school"
+        title="졸업요건"
+        majorRequired={true}
+        onClick={() => openLink(graduationLink)}
+      />
+    </>
+  );
+};
+
+export default InformCardList;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,49 +1,15 @@
-import http from '@apis/http';
-import InformCard from '@components/Card/InformCard';
 import Carousel from '@components/Carousel';
 import styled from '@emotion/styled';
-import useMajor from '@hooks/useMajor';
-import useRouter from '@hooks/useRouter';
 import { THEME } from '@styles/ThemeProvider/theme';
-import { AxiosResponse } from 'axios';
-import { useEffect, useState } from 'react';
+
+import InformCardList from './components/InformCardList';
 
 const Home = () => {
-  const [graduationLink, setGraduationLink] = useState<string | null>('');
-  const { routerTo } = useRouter();
-  const { major } = useMajor();
-
-  const routerToGraduationRequiredPage = (graduationLink: string | null) => {
-    graduationLink && window.open(graduationLink, '_blank');
-  };
-
-  useEffect(() => {
-    if (!major) return;
-    const getGraduationLink = async () => {
-      const response: AxiosResponse<GraduationLink> = await http.get(
-        `/api/graduation?major=${major}`,
-      );
-      setGraduationLink(response.data.link);
-    };
-    getGraduationLink();
-  }, [major]);
-
   return (
     <Container>
       <InformCardWrapper>
         <InformTitle>학교</InformTitle>
-        <InformCard
-          icon="notification"
-          title="공지사항"
-          majorRequired={false}
-          onClick={() => routerTo('/announcement')}
-        />
-        <InformCard
-          icon="school"
-          title="졸업요건"
-          majorRequired={true}
-          onClick={() => routerToGraduationRequiredPage(graduationLink)}
-        />
+        <InformCardList />
       </InformCardWrapper>
       <InformCardWrapper>
         <InformTitle>비교과</InformTitle>
@@ -76,8 +42,3 @@ const InformTitle = styled.div`
   font-size: 20px;
   font-weight: bold;
 `;
-
-interface GraduationLink {
-  department: string;
-  link: string | null;
-}

--- a/src/pages/MajorDecision/index.test.tsx
+++ b/src/pages/MajorDecision/index.test.tsx
@@ -15,7 +15,9 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe.skip('학과선택 페이지 로직 테스트', () => {
+  const mockGraduationLink = 'https://ce.pknu.ac.kr/ce/2889';
   const mockSetMajor = jest.fn();
+
   beforeEach(() => {
     jest.mock('react', () => ({
       ...jest.requireActual('react'),
@@ -30,7 +32,13 @@ describe.skip('학과선택 페이지 로직 테스트', () => {
   it('전공 선택 버튼 클릭 후, 상태 변경 테스트', async () => {
     render(
       <MemoryRouter>
-        <MajorContext.Provider value={{ major: null, setMajor: mockSetMajor }}>
+        <MajorContext.Provider
+          value={{
+            major: null,
+            setMajor: mockSetMajor,
+            graduationLink: mockGraduationLink,
+          }}
+        >
           <MajorDecision />
         </MajorContext.Provider>
       </MemoryRouter>,

--- a/src/utils/router/openLink.ts
+++ b/src/utils/router/openLink.ts
@@ -1,0 +1,5 @@
+export default function openLink(link: string | null) {
+  if (!link) return;
+
+  window.open(link, '_blank');
+}


### PR DESCRIPTION
## 🤠 개요

- 공지사항 리스트 UI를 수정했어요
- 공지사항 검색 기능을 추가했어요


## 💫 설명

> 기존의 공지사항 페이지는 공지사항 페이지 내부에서 학교, 학과 공지사항을 나누어서 보여줬고 일반,  고정 공지사항은 확성기 아이콘을 통해서 구분하고 스크롤을 통해서 아래로 내려가야만 일반 공지사항을 확인할 수 있었어요. 만약, 알림이 왔을 때 해당 공지사항이 일반 공지사항이라면 사용자가 확인하기 위해서 아래로 내려가야 하고, 고정 공지사항의 양에 비례해서 스크롤도 많아지므로 불편함으로 이어질 수 있겠다고 생각했어요. 따라서 홈페이지에서 학교, 학과 공지사항을 구분하고 **각 공지사항 페이지 내부에서 일반, 고정 공지사항을 버튼으로 구분**하기로 했어요. 그리고, 공지사항 검색 기능도 추가 했어요

- 일반, 고정 공지사항 구분 예시
  - 일반 : `/announcement/school/normal`
  - 고정 : `/announcement/school/pinned`

- 검색 공지사항 예시
  - 검색 : `/announcement/school/search?q=프로그래밍`

검색을 하면 url이 변경되고 컴포넌트가 리렌더링 되어서 api 호출 하는 코드도 한번 더 실행되는 문제가 있었어요. 이미 가져온 데이터에 검색 키워드가 있는지 확인하는데, url을 변경하다보니 불필요한 api 호출을 하기 때문에 `useMemo`를 활용해서 컴포넌트가 처음 렌더링 될 때만 api 호출을 하도록 했어요




## 📷 스크린샷 (Optional)
### 변겅 전

<img src = 'https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/68489467/80b48abd-f7a5-4fcf-b8a0-b26daa4f543f' width = '250px' height = '600px' />

### 변경 후

<div> 
<img src = 'https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/68489467/37db2249-6475-40bd-bb21-273e58934953' width = '250px' height = '600px' />
<img src = 'https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/68489467/9578e9f6-e5ed-49cf-a711-6e9000d51793' width = '250px' height = '600px' />
<img src = 'https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/68489467/292a2805-dd28-44b9-9b60-dabb93bd7c9a' width = '250px' height = '600px' />
</ div>

