### PR TITLE
Refactor/#294: MajorProvider에서 졸업요건 링크 상태 삭제

### DIFF
--- a/src/components/List/DepartmentList/index.test.tsx
+++ b/src/components/List/DepartmentList/index.test.tsx
@@ -31,7 +31,6 @@ jest.mock('@hooks/useModals', () => {
 });
 
 describe.skip('학과선택 테스트', () => {
-  const mockGraduationLink = 'https://ce.pknu.ac.kr/ce/2889';
   const mockUseMajor = useMajor as jest.MockedFunction<typeof useMajor>;
   const mockSetMajor = jest.fn();
 
@@ -39,7 +38,6 @@ describe.skip('학과선택 테스트', () => {
     mockUseMajor.mockReturnValue({
       setMajor: mockSetMajor,
       major: '컴퓨터공학과',
-      graduationLink: mockGraduationLink,
     });
   });
 

--- a/src/components/Providers/MajorProvider/index.tsx
+++ b/src/components/Providers/MajorProvider/index.tsx
@@ -1,12 +1,5 @@
-import http from '@apis/http';
 import MajorContext from '@contexts/major';
-import { AxiosResponse } from 'axios';
 import React, { useEffect, useState } from 'react';
-
-interface GraduationLink {
-  department: string;
-  link: string | null;
-}
 
 interface MajorProviderProps {
   children: React.ReactNode;
@@ -14,28 +7,16 @@ interface MajorProviderProps {
 
 const MajorProvider = ({ children }: MajorProviderProps) => {
   const [major, setMajor] = useState<string | null>(null);
-  const [graduationLink, setGraduationLink] = useState<string | null>('');
 
   useEffect(() => {
     const storedMajor = localStorage.getItem('major');
     if (!storedMajor) return;
+
     setMajor(storedMajor);
   }, []);
 
-  useEffect(() => {
-    if (!major) return;
-
-    (async () => {
-      const response: AxiosResponse<GraduationLink> = await http.get(
-        `/api/graduation?major=${major}`,
-      );
-      const graduationLink = response.data.link;
-      setGraduationLink(graduationLink);
-    })();
-  }, [major]);
-
   return (
-    <MajorContext.Provider value={{ major, setMajor, graduationLink }}>
+    <MajorContext.Provider value={{ major, setMajor }}>
       {children}
     </MajorContext.Provider>
   );

--- a/src/contexts/major.ts
+++ b/src/contexts/major.ts
@@ -4,7 +4,6 @@ import { createContext } from 'react';
 interface MajorState {
   major: Major;
   setMajor: React.Dispatch<React.SetStateAction<Major>>;
-  graduationLink: string | null;
 }
 
 const MajorContext = createContext<MajorState | null>(null);

--- a/src/pages/Home/components/InformCardList.tsx
+++ b/src/pages/Home/components/InformCardList.tsx
@@ -1,14 +1,24 @@
+import http from '@apis/http';
 import InformCard from '@components/Card/InformCard';
 import { ANNOUNCEMENT_TITLE } from '@constants/announcement';
 import PATH from '@constants/path';
 import useMajor from '@hooks/useMajor';
 import useRouter from '@hooks/useRouter';
 import openLink from '@utils/router/openLink';
+import { AxiosResponse } from 'axios';
 import React from 'react';
 
 const InformCardList = () => {
-  const { graduationLink } = useMajor();
+  const { major } = useMajor();
   const { routerTo } = useRouter();
+
+  const onGraduationCardClick = async () => {
+    const response: AxiosResponse<string> = await http.get(
+      `/api/graduation?major=${major}`,
+    );
+    const graduationLink = response.data;
+    openLink(graduationLink);
+  };
 
   return (
     <>
@@ -28,7 +38,7 @@ const InformCardList = () => {
         icon="school"
         title="졸업요건"
         majorRequired={true}
-        onClick={() => openLink(graduationLink)}
+        onClick={onGraduationCardClick}
       />
     </>
   );

--- a/src/pages/MajorDecision/index.test.tsx
+++ b/src/pages/MajorDecision/index.test.tsx
@@ -15,7 +15,6 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe.skip('학과선택 페이지 로직 테스트', () => {
-  const mockGraduationLink = 'https://ce.pknu.ac.kr/ce/2889';
   const mockSetMajor = jest.fn();
 
   beforeEach(() => {
@@ -36,7 +35,6 @@ describe.skip('학과선택 페이지 로직 테스트', () => {
           value={{
             major: null,
             setMajor: mockSetMajor,
-            graduationLink: mockGraduationLink,
           }}
         >
           <MajorDecision />


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- closes : #294 

## 💫 설명

<!--

- 현재 Pr 설명

-->

- `MajorProvider`에서 Context API를 사용해 졸업요건 링크 상태를 의존성으로 주입했던 로직을 삭제했어요.
- 대신, 졸업요건 카드를 클릭할 때마다 졸업요건 링크를 가져오는 api 요청을 보내고 해당링크로 이동 시키는 로직을 `InformCardList` 컴포넌트에 추가했어요

## 📷 스크린샷 (Optional)
