### PR TITLE
Feat/#306: 채용공지사항 기능 추가

### DIFF
--- a/src/components/Card/AnnounceCard/index.tsx
+++ b/src/components/Card/AnnounceCard/index.tsx
@@ -6,26 +6,36 @@ import openLink from '@utils/router/openLink';
 
 interface AnnounceCardProps extends AnnounceItem {
   author?: string;
+  recruitment_period?: string;
 }
 
 const AnnounceCard = ({
   title,
   link,
   uploadDate,
+  recruitment_period,
   author,
 }: AnnounceCardProps) => {
   const { major } = useMajor();
 
-  uploadDate = uploadDate.slice(2);
+  const showDate = () => {
+    if (recruitment_period) return recruitment_period;
+    uploadDate = uploadDate.slice(2);
+    return `20${uploadDate}`;
+  };
 
   return (
     <Card onClick={() => openLink(link)} data-testid="card">
       <ContentContainer>
         <AnnounceTitle>{title}</AnnounceTitle>
         <SubContent>
-          <AnnounceDate>20{uploadDate}</AnnounceDate>
-          <VertialBoundaryLine />
-          <Source>{author ? author : major}</Source>
+          <AnnounceDate>{showDate()}</AnnounceDate>
+          {!recruitment_period && (
+            <>
+              <VertialBoundaryLine />
+              <Source>{author ? author : major}</Source>
+            </>
+          )}
         </SubContent>
       </ContentContainer>
       <HorizonBoundaryLine />

--- a/src/pages/Announcement/index.tsx
+++ b/src/pages/Announcement/index.tsx
@@ -44,6 +44,16 @@ const Announcement = () => {
           />
         }
       />
+      <Route
+        path={PATH.RECRUIT_ANNOUNCEMENT}
+        element={
+          <AnnounceContainer
+            title={ANNOUNCEMENT_TITLE.RECRUIT}
+            category={ANNOUNCEMENT_CATEGORY.RECRUIT}
+            endPoint={'/recruit'}
+          />
+        }
+      />
     </Routes>
   );
 };


### PR DESCRIPTION
## 🤠 개요

- closes: #306 
- 채용 공지사항을 볼 수 있도록 기능을 추가했어요
- 채용 공지사항의 경우 업로드 날짜가 아닌 채용 기간을 보여주고 작성자는 보여주지 않도록 했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="480" alt="image" src="https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/71641127/84243f4a-9b76-4684-bf58-05242200a7fc">
