### PR TITLE
Fix/#311: 공지사항 페이지에서 히스토리 관리 추가

### DIFF
--- a/src/hooks/useRouter.ts
+++ b/src/hooks/useRouter.ts
@@ -6,6 +6,7 @@ const useRouter = () => {
   return {
     currentPath: window.location.pathname,
     routerTo: (path: To) => router(path),
+    replaceTo: (path: To) => router(path, { replace: true }),
     goBack: () => router(-1 as To),
   };
 };

--- a/src/pages/Announcement/components/AnnounceContainer.tsx
+++ b/src/pages/Announcement/components/AnnounceContainer.tsx
@@ -30,12 +30,12 @@ const AnnounceContainer = ({
   const { type } = useParams();
   if (!type) return <></>;
 
-  const { routerTo } = useRouter();
+  const { replaceTo } = useRouter();
 
   const showNormalAnnouncement = () =>
-    routerTo(PATH.NORMAL_ANNOUNCEMENT(category));
+    replaceTo(PATH.NORMAL_ANNOUNCEMENT(category));
   const showPinnedAnnouncement = () =>
-    routerTo(PATH.PINNED_ANNOUNCEMENT(category));
+    replaceTo(PATH.PINNED_ANNOUNCEMENT(category));
 
   const resource = useMemo(
     () => fetchAnnounceList<AnnounceItemList>(endPoint),


### PR DESCRIPTION
## 🤠 개요

- closes: #311 
- 일반/고정 공지사항을 왔다갔다하고 뒤로가기를 누르면 홈 화면으로 이동할 수 있도록 라우팅 히스토리 관리할 수 있도록 했어요
- useRouter 훅에서 replaceTo 함수를 이용해 현재 히스토리를 대체하며 이동할 수 있어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)

https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/71641127/bb46c5a7-3c9d-4ca5-b1b7-02ad75a75509

