### PR TITLE
Reafactor(FAQBox): 재사용 컴포넌트 ToggleInfo 적용

### DIFF
--- a/src/components/FAQBox/index.tsx
+++ b/src/components/FAQBox/index.tsx
@@ -1,10 +1,10 @@
-import Icon from '@components/Common/Icon';
+import ToggleInfo from '@components/Common/ToggleInfo';
 import { FAQ_CONSTANTS } from '@constants/FAQ';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { THEME } from '@styles/ThemeProvider/theme';
 import openLink from '@utils/router/openLink';
-import React, { useState } from 'react';
+import React from 'react';
 
 interface FAQBoxProps {
   readonly question: string;
@@ -15,35 +15,38 @@ interface FAQBoxProps {
 }
 
 const FAQBox = ({ question, answer }: FAQBoxProps) => {
-  const [showAnswer, setShowAnswer] = useState<boolean>(false);
-  const toggleAnswer = () => setShowAnswer((prevState) => !prevState);
-
-  const seperatedAnswerText = answer.text.split(FAQ_CONSTANTS.LINE_SEPERATOR);
   const moveToLink = () => {
     if (!answer.link) return;
+
     openLink(answer.link);
   };
-  const hasAnswerLink = () => !!answer.link;
+
+  const hasLink = !!answer.link;
 
   return (
     <>
-      <QuestionContainer onClick={toggleAnswer} showAnswer={showAnswer}>
-        <QuestionMark>{FAQ_CONSTANTS.QUESTION_MARK}</QuestionMark>
-        <QuestionText>{question}</QuestionText>
-        <IconContainer>
-          <Icon kind="arrowDown" size="24" />
-        </IconContainer>
-      </QuestionContainer>
-      {showAnswer && (
-        <AnswerContainer>
-          {seperatedAnswerText.map((line, index) => (
-            <p key={index}>{line}</p>
-          ))}
-          {hasAnswerLink() && (
-            <StyledLink onClick={moveToLink}>{FAQ_CONSTANTS.LINK}</StyledLink>
-          )}
-        </AnswerContainer>
-      )}
+      <ToggleInfo
+        infoTitle={() => (
+          <>
+            <span
+              css={css`
+                font-weight: bold;
+              `}
+            >
+              {FAQ_CONSTANTS.QUESTION_MARK}
+            </span>
+            <QuestionText>{question}</QuestionText>
+          </>
+        )}
+        infoDesc={() => (
+          <AnswerContainer>
+            {answer.text}
+            {hasLink && (
+              <StyledLink onClick={moveToLink}>{FAQ_CONSTANTS.LINK}</StyledLink>
+            )}
+          </AnswerContainer>
+        )}
+      />
       <BoundaryLine />
     </>
   );
@@ -51,35 +54,8 @@ const FAQBox = ({ question, answer }: FAQBoxProps) => {
 
 export default FAQBox;
 
-const QuestionContainer = styled.div<{ showAnswer: boolean }>`
-  position: relative;
-  padding: 10px 0px 10px 0px;
-  display: flex;
-  align-items: center;
-
-  ${({ showAnswer }) => css`
-    & > span {
-      color: ${showAnswer && THEME.PRIMARY};
-    }
-    & > div > svg {
-      transform: ${showAnswer ? 'rotate(-180deg)' : 'rotate(0deg)'};
-      transition: all ease 0.3s;
-    }
-  `}
-`;
-
-const QuestionMark = styled.span`
-  font-weight: bold;
-`;
-
 const QuestionText = styled.span`
   text-indent: 1rem;
-`;
-
-const IconContainer = styled.div`
-  position: absolute;
-  right: 0;
-  display: flex;
 `;
 
 const AnswerContainer = styled.div`
@@ -89,6 +65,7 @@ const AnswerContainer = styled.div`
   padding: 10px 20px 10px 20px;
   border-radius: 10px;
   margin-bottom: 10px;
+  white-space: pre-line;
 `;
 
 const StyledLink = styled.span`

--- a/src/constants/FAQ/faq-data.ts
+++ b/src/constants/FAQ/faq-data.ts
@@ -34,7 +34,7 @@ const FAQ_DATA: FAQ[] = [
   {
     question: '이미 앱스토어로 다운 받았어요.(IOS)',
     answer: {
-      text: '이미 앱스토어로 다운 받으셨다면 기존의 앱을 지운 후 아래의 링크로 이동해 방법을 따라해주세요 :)',
+      text: '이미 앱스토어로 다운 받으셨다면 기존의 앱을 지운 후 아래의 링크로 이동해 방법을 따라해주세요 :)\n',
       link: 'https://burimi.notion.site/IOS-71bbd68542f24b8db00718367d327597',
     },
   },


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- closes : #316 

## 💫 설명

<!--

- 현재 Pr 설명

-->

- FAQ 페이지에 재사용 컴포넌트 `ToggleInfo`를 적용했어요
- 줄바꿈 문자를 기준으로 문자열을 `split`을 하고 배열 메서드 `map`을 적용했는데 사실 css로 간단하게 해결할 수 있는 문제더라고요...😅 그래서 변경했습니다.
```css
{
	white-space : pre-line
}
```

## 📷 스크린샷 (Optional)
