### PR TITLE
Fix/#320: 자잘한 UI 수정

### DIFF
--- a/src/components/InformUpperLayout/InformSearchForm.tsx
+++ b/src/components/InformUpperLayout/InformSearchForm.tsx
@@ -5,6 +5,7 @@ import TOAST_MESSAGES from '@constants/toast-message';
 import styled from '@emotion/styled';
 import useRouter from '@hooks/useRouter';
 import useToasts from '@hooks/useToast';
+import { THEME } from '@styles/ThemeProvider/theme';
 import React, { useRef } from 'react';
 
 interface InformSearchForm {
@@ -60,12 +61,12 @@ const StyledInput = styled.input`
   border: 0;
   border-radius: 15px;
   background-color: #7a9dd30f;
-  color: #7a9dd366;
+  color: ${THEME.TEXT.BLACK};
   font-size: 14px;
   text-indent: 5px;
 
   &::placeholder {
-    color: #7a9dd366;
+    color: ${THEME.TEXT.GRAY};
     font-size: 14px;
   }
   box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.15);

--- a/src/pages/Home/components/InformHalfCard.tsx
+++ b/src/pages/Home/components/InformHalfCard.tsx
@@ -51,7 +51,8 @@ const TitleWrapper = styled.div`
 `;
 
 const Title = styled.h2`
-  font-size: 16px;
+  font-size: 14px;
+  white-space: nowrap;
   font-weight: bold;
 `;
 
@@ -59,6 +60,6 @@ const SubTitle = styled.h3`
   color: ${THEME.TEXT.SEMIBLACK};
   display: flex;
   justify-content: flex-end;
-  font-size: 13px;
+  font-size: 11px;
   padding-bottom: 6px;
 `;


### PR DESCRIPTION
## 🤠 개요

- closes: #320 
- Input 컴포넌트의 색상을 placeholder 는 회색, 글자는 검은색으로 수정
- 홈 화면의 HalfCard 컴포넌트의 글자가 2줄로 처리되지 않도록 수정
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="451" alt="image" src="https://github.com/GDSC-PKNU-Official/pknu-notice-front/assets/71641127/004f17d3-3049-4167-8389-422a5e063c6f">
